### PR TITLE
Add support for books from portal.oebv.at

### DIFF
--- a/src/item/ItemRef.ts
+++ b/src/item/ItemRef.ts
@@ -3,6 +3,7 @@ import { Archive } from './Archive';
 import { BiBoxBook } from './BiBoxBook';
 import { DigiBook } from './DigiBook';
 import { Item } from './Item';
+import { OebvBook } from './OebvBook';
 import { ScookBook } from './ScookBook';
 
 export class ItemRef {
@@ -26,6 +27,10 @@ export class ItemRef {
         return new BiBoxBook(this.shelf, pageUrl, this.title);
       }
 
+      if (pageUrl.includes('portal.oebv.at')) {
+        return new OebvBook(this.shelf, pageUrl, this.title);
+      }
+    
       if ((await page.$('#loadPage')) != null) {
         return new DigiBook(this.shelf, pageUrl, this.title);
       }

--- a/src/item/OebvBook.ts
+++ b/src/item/OebvBook.ts
@@ -1,0 +1,86 @@
+import { promisePool } from '../util/promise';
+import { waitForGoto } from '../util/puppeteer';
+import { URL } from 'url';
+import { Book } from './Book';
+import { defDownloadOptions, DownloadOptions } from './download-options';
+import { getPdfOptions } from './get-pdf-options';
+import { ScrapeError } from '../error/ScrapeError';
+
+export class OebvBook extends Book {
+  async download(outDir: string, _options?: DownloadOptions) {
+    const dir = await this.mkSubDir(outDir);
+    const options = defDownloadOptions(_options);
+
+    // Get url of 1st page
+    const checkPage = await this.shelf.browser.newPage();
+    let page1Url: string;
+    let pageCount: number;
+    try {
+      await checkPage.goto(new URL(`?page=1`, this.url).toString(), {
+        waitUntil: 'networkidle2',
+        timeout: this.shelf.options.timeout,
+      });
+      page1Url = new URL(`content/pages/page_1/Scale4.png`, this.url).toString();
+      pageCount = await checkPage.$$eval(
+        'footer > nav > ul > li',
+        (elms) => elms.length
+      );
+    } finally {
+      await checkPage.close();
+    }
+
+    // Page download pool
+    let downloadedPages = 0;
+    const getProgress = () => ({
+      item: this,
+      percentage: downloadedPages / pageCount,
+      downloadedPages,
+      pageCount,
+    });
+    options.onStart(getProgress());
+
+    await promisePool(async (pageNo, stop) => {
+      const page = await this.shelf.browser.newPage();
+      try {
+        // Go to current page
+        const base = this.url.replace(/(?<=\/)[^\/]+$/g, '');
+        const pageUrl = new URL(
+          page1Url
+            .slice(base.length)
+            .replace(/(?<=page_|^)1(?=\/|\.|$)/gm, pageNo.toString()),
+          base
+        ).toString();
+        const res = await waitForGoto(
+          page,
+          await page.goto(pageUrl, {
+            waitUntil: 'networkidle0',
+            timeout: this.shelf.options.timeout,
+          })
+        );
+        if (!res.ok()) return stop();
+
+        // Save it as pdf
+        const pdfFile = this.getPdfPath(dir, pageNo + 1);
+
+        await page.pdf({
+          ...(await getPdfOptions(page, options)),
+          path: pdfFile,
+        });
+
+        downloadedPages++;
+        options.onProgress(getProgress());
+      } finally {
+        await page.close();
+      }
+    }, options.concurrency);
+
+    if (downloadedPages != pageCount) {
+      throw new ScrapeError(
+        `A page count of ${pageCount} was parsed, but ${downloadedPages} were downloaded. Please report this issue.`
+      );
+    }
+
+    // Merge pdf pages
+    options.mergePdfs && (await this.mergePdfPages(dir, downloadedPages));
+  }
+}


### PR DESCRIPTION
Some books in my shelf are located on portal.oebv.at. The pages are only available in png format in 4 zoom levels. I have only added support for the highest (level 4). This PR adds support for downloading these.
Disclaimer: I'm not a TypeScript developer and I've heavily relied on the implementation of `DigiBook`.