### PR TITLE
Fixed Problem with new Scook Login

### DIFF
--- a/src/shelf/ScookShelf.ts
+++ b/src/shelf/ScookShelf.ts
@@ -15,8 +15,8 @@ export class ScookShelf extends Shelf {
   protected async login() {
     await this.formLogin(
       '/auth/puma',
-      '#Input_Username',
-      '#input-login-password',
+      '#Input_UsernameOrEmail',
+      '#Input_Password',
       'form#account button[type="submit"]',
       (page) =>
         Promise.race([


### PR DESCRIPTION
The Login gets redirected to a new Login Page, therefor the ids of the input forms are different.
Fixes #13 